### PR TITLE
removed dependency on the features for fs_walk and path ext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ path = "src/lib.rs"
 
 [dependencies]
 tempdir = "*"
+walkdir = "1"


### PR DESCRIPTION
I wrote some, somewhat quickly, a code work arounds to make this compile with release versions of rustc. I didn't notice any tests or documentation on how to test this, so I didn't do so. 